### PR TITLE
Completion for rake tasks without a description

### DIFF
--- a/rake
+++ b/rake
@@ -7,7 +7,7 @@ _rakecomplete() {
     if [ -f Rakefile ]; then
         recent=`ls -t .rake_tasks~ Rakefile **/*.rake 2> /dev/null | head -n 1`
         if [[ $recent != '.rake_tasks~' ]]; then
-            rake --silent --tasks | cut -d " " -f 2 > .rake_tasks~
+            rake --silent --prereqs | grep "rake" | cut -d " " -f 2 > .rake_tasks~
         fi
         COMPREPLY=($(compgen -W "`cat .rake_tasks~`" -- ${COMP_WORDS[COMP_CWORD]}))
         return 0


### PR DESCRIPTION
Currently, your script does not support completion for rake tasks that do not have a description.

I changed the cache generation command to support these tasks. It adds an additional 5% performance hit when generating the cache, since it pipes a larger output through grep. YMMV.
